### PR TITLE
Avoid key_image validation while blockchain size is less than 780000

### DIFF
--- a/src/currency_core/blockchain_storage.cpp
+++ b/src/currency_core/blockchain_storage.cpp
@@ -2045,15 +2045,7 @@ bool blockchain_storage::check_tx_input(const txin_to_key& txin, const crypto::h
   if (!crypto::validate_key_image(txin.k_image))
   {
     LOG_ERROR("Invalid key image: " << txin.k_image << ", amount: " << print_money(txin.amount) << ", tx: " << tx_prefix_hash);
-<<<<<<< HEAD
     if (m_blocks.size() > 780000) // unfortunately, there are invalid keyimages in blockchain, skip the checking for them
-=======
-    size_t top_block_height = 0;
-    CRITICAL_REGION_BEGIN(m_blockchain_lock);
-    top_block_height = m_blocks.size() - 1;
-    CRITICAL_REGION_END();
-    if (top_block_height > 780000) // unfortunately, there are invalid keyimages in blockchain, skip the checking for them
->>>>>>> eddc2390a6d9594b2b79f91929128f36c2c84f5c
       return false;
   }
 

--- a/src/currency_core/blockchain_storage.cpp
+++ b/src/currency_core/blockchain_storage.cpp
@@ -2042,8 +2042,16 @@ bool blockchain_storage::check_tx_input(const txin_to_key& txin, const crypto::h
   if(m_is_in_checkpoint_zone)
     return true;
 
-  bool r = crypto::validate_key_image(txin.k_image);
-  CHECK_AND_ASSERT_MES(r, false, "Failed to validate key image");
+  if (!crypto::validate_key_image(txin.k_image))
+  {
+    LOG_ERROR("Invalid key image: " << txin.k_image << ", amount: " << print_money(txin.amount) << ", tx: " << tx_prefix_hash);
+    size_t top_block_height = 0;
+    CRITICAL_REGION_BEGIN(m_blockchain_lock);
+    top_block_height = m_blocks.size() - 1;
+    CRITICAL_REGION_END();
+    if (top_block_height > 780000) // unfortunately, there are invalid keyimages in blockchain, skip the checking for them
+      return false;
+  }
 
   CHECK_AND_ASSERT_MES(sig.size() == output_keys.size(), false, "internal error: tx signatures count=" << sig.size() << " mismatch with outputs keys count for inputs=" << output_keys.size());
   return crypto::check_ring_signature(tx_prefix_hash, txin.k_image, output_keys, sig.data());

--- a/src/currency_core/blockchain_storage.cpp
+++ b/src/currency_core/blockchain_storage.cpp
@@ -2045,11 +2045,15 @@ bool blockchain_storage::check_tx_input(const txin_to_key& txin, const crypto::h
   if (!crypto::validate_key_image(txin.k_image))
   {
     LOG_ERROR("Invalid key image: " << txin.k_image << ", amount: " << print_money(txin.amount) << ", tx: " << tx_prefix_hash);
+<<<<<<< HEAD
+    if (m_blocks.size() > 780000) // unfortunately, there are invalid keyimages in blockchain, skip the checking for them
+=======
     size_t top_block_height = 0;
     CRITICAL_REGION_BEGIN(m_blockchain_lock);
     top_block_height = m_blocks.size() - 1;
     CRITICAL_REGION_END();
     if (top_block_height > 780000) // unfortunately, there are invalid keyimages in blockchain, skip the checking for them
+>>>>>>> eddc2390a6d9594b2b79f91929128f36c2c84f5c
       return false;
   }
 


### PR DESCRIPTION
atm there are 7 txs with malformed key_imges in the blockchain, we should skip them